### PR TITLE
Parameterize test-definitions

### DIFF
--- a/tuxrun/__main__.py
+++ b/tuxrun/__main__.py
@@ -189,6 +189,7 @@ def run(options, tmpdir: Path, cache_dir: Optional[Path], artefacts: dict) -> in
     test_definitions = None
     if any(t.need_test_definition for t in options.tests):
         test_definitions = get_test_definitions(
+            options.test_definitions,
             ProgressIndicator.get("Downloading test definitions")
         )
         extra_assets.append(test_definitions)

--- a/tuxrun/argparse.py
+++ b/tuxrun/argparse.py
@@ -25,6 +25,7 @@ def filter_options(options):
         "device",
         "tuxbuild",
         "tuxmake",
+        "test_definitions",
         "timeouts",
         "runtime",
         "image",
@@ -302,6 +303,7 @@ def setup_parser() -> argparse.ArgumentParser:
         type=tuxmake_directory,
         help="directory containing a TuxMake build",
     )
+    artefact("test-definitions")
     artefact("uefi")
     group.add_argument(
         "--fvp-ubl-license",

--- a/tuxrun/assets.py
+++ b/tuxrun/assets.py
@@ -25,8 +25,8 @@ def get_rootfs(
     return __download_and_cache__(rootfs or device.rootfs, progress)
 
 
-def get_test_definitions(progress: ProgressIndicator = NoProgressIndicator()):
-    return pathurlnone(__download_and_cache__(TEST_DEFINITIONS, progress))
+def get_test_definitions(test_definitions: str = "", progress: ProgressIndicator = NoProgressIndicator()):
+    return pathurlnone(__download_and_cache__(test_definitions or TEST_DEFINITIONS, progress))
 
 
 def __download_and_cache__(


### PR DESCRIPTION
Provide an argument to allow a user to pass a path to a local test definitions zstd compressed tarball.